### PR TITLE
Detect AFIP invoice type from OCR tokens

### DIFF
--- a/tests/test_ie_extract.py
+++ b/tests/test_ie_extract.py
@@ -1,0 +1,11 @@
+import sys
+sys.path.insert(0, 'services/api')
+
+from app.utils.ie_extract import extract_fields
+import pytest
+
+@pytest.mark.parametrize('letter', ['A', 'B', 'C', 'M'])
+def test_detect_invoice_letter(letter):
+    tokens = ['Factura', letter, '0001-00000001']
+    campos = extract_fields({'tokens': tokens})
+    assert campos['tipo'] == letter


### PR DESCRIPTION
## Summary
- Detect invoice letter A/B/C/M from OCR tokens using regex heuristics
- Populate extracted `tipo` field with detected AFIP invoice type
- Add tests ensuring invoice type detection works for common letters

## Testing
- `pytest tests/test_ie_extract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f74b79c4832db47ac24ef7126bfa