### PR TITLE
Use callable default for JSONB

### DIFF
--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -20,6 +20,6 @@ class Documento(Base):
     fecha_emision = Column(Date)
     moneda = Column(String, default="ARS")
     total = Column(Numeric(18,2))
-    meta = Column(JSONB, default={})  # netos, iva por alícuota, etc.
+    meta = Column(JSONB, default=dict)  # netos, iva por alícuota, etc.
     hash_archivo = Column(String, unique=True)
     ruta_archivo = Column(Text)


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults for Documento meta JSONB column

## Testing
- `alembic revision --autogenerate -m "Use dict default for JSONB"` *(fails: No 'script_location' key found in configuration.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5f74bdec0832d958dd9a15de3dec8