### PR TITLE
Record uploaded document and return ID

### DIFF
--- a/services/api/app/routers/ingest.py
+++ b/services/api/app/routers/ingest.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, UploadFile, File, Depends
 from pathlib import Path
+from sqlalchemy.orm import Session
 from ..config import settings
+from ..db import get_db
+from ..models import Documento
 from ..schemas import ProcesamientoOut
 from ..utils.ocr_pipeline import run_ocr
 from ..utils.ie_extract import extract_fields
@@ -11,19 +14,29 @@ from ..utils.exporters import export_outputs
 router = APIRouter(prefix="/ingesta", tags=["ingesta"])
 
 @router.post("/procesar", response_model=ProcesamientoOut)
-async def procesar(file: UploadFile = File(...)):
+async def procesar(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
     target = Path(settings.STORAGE_DIR) / file.filename
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("wb") as f:
         f.write(await file.read())
 
+    doc = Documento(tipo=file.content_type or "desconocido", ruta_archivo=str(target))
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    doc_id = str(doc.id)
+
     ocr = run_ocr(target)
     campos = extract_fields(ocr)
     vals = validate_fields(campos)
     asiento = propose_entry(campos)
-    exports = export_outputs("doc-id-placeholder")
+    exports = export_outputs(doc_id)
 
     return {
+        "documento_id": doc_id,
         "validaciones": vals,
         "campos_extraidos": campos,
         "asiento_propuesto": asiento,

--- a/services/api/app/routers/ingest_universal.py
+++ b/services/api/app/routers/ingest_universal.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, UploadFile, File, Depends
 from pathlib import Path
+from sqlalchemy.orm import Session
 from ..config import settings
+from ..db import get_db
+from ..models import Documento
 from ..utils.universal_pipeline import procesar_universal
 from ..utils.validators import validate_fields
 from ..utils.accounting_rules import propose_entry
@@ -10,18 +13,28 @@ from ..utils.exporters import export_outputs
 router = APIRouter(prefix="/ingesta", tags=["ingesta"])
 
 @router.post("/procesar_universal")
-async def procesar_universal(file: UploadFile = File(...)):
+async def procesar_universal(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
     target = Path(settings.STORAGE_DIR) / file.filename
     target.parent.mkdir(parents=True, exist_ok=True)
     with target.open("wb") as f:
         f.write(await file.read())
 
+    doc = Documento(tipo=file.content_type or "desconocido", ruta_archivo=str(target))
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    doc_id = str(doc.id)
+
     result = procesar_universal(target)
     vals = validate_fields(result["campos_extraidos"])
     asiento = propose_entry(result["campos_extraidos"])
-    exports = export_outputs("doc-id-placeholder")
+    exports = export_outputs(doc_id)
 
     out = {
+        "documento_id": doc_id,
         "validaciones": vals,
         "campos_extraidos": result["campos_extraidos"],
         "asiento_propuesto": asiento,
@@ -29,6 +42,6 @@ async def procesar_universal(file: UploadFile = File(...)):
         "libros_y_ddjj_preliminares": {"iva": {}, "ganancias": {}, "iibb": {}},
         "archivos_exportables": exports["files"],
         "items": result["items"],
-        "pages": result["pages"]
+        "pages": result["pages"],
     }
     return out

--- a/services/api/app/schemas.py
+++ b/services/api/app/schemas.py
@@ -24,6 +24,7 @@ class LibrosDDJJ(BaseModel):
     iibb: Dict[str, Any]
 
 class ProcesamientoOut(BaseModel):
+    documento_id: str
     validaciones: List[Validacion]
     campos_extraidos: Dict[str, Any]
     asiento_propuesto: AsientoPropuesto


### PR DESCRIPTION
## Summary
- Create `Documento` database entries when ingesting files
- Use stored document UUID for exports and expose it in API responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5f74bde1c832d88a0b9456de5f654